### PR TITLE
fix: cw execution will exclude all notes without cw

### DIFF
--- a/packages/backend/src/server/api/endpoints/notes/featured.ts
+++ b/packages/backend/src/server/api/endpoints/notes/featured.ts
@@ -68,8 +68,11 @@ export default class extends Endpoint<typeof meta, typeof paramDef> {
 					new Brackets(qb => {
 						qb.where('note.text NOT LIKE \'%おはよう%\'')
 							.andWhere('note.text NOT LIKE \'%:ohayo_nirila_misskey:%\'')
-							.andWhere('note.cw NOT LIKE \'%おはよう%\'')
-							.andWhere('note.cw NOT LIKE \'%:ohayo_nirila_misskey:%\'')
+							.andWhere(new Brackets(qb => {
+								qb.where('note.cw NOT LIKE \'%おはよう%\'')
+									.andWhere('note.cw NOT LIKE \'%:ohayo_nirila_misskey:%\'')
+									.orWhere('note.cw IS NULL');
+							}))
 							.orWhere('note.fileIds != \'{}\'');
 					}),
 				);


### PR DESCRIPTION
bugfix: CWないnoteが表示されないバグがあった