### PR TITLE
fix: muted user's notes are not removed in featured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## 2023.x.x (unreleased)
 
 ### General
+- Fix: 全体ハイライトでユーザーミュートが正常に機能しない問題
 
 ### Client
 

--- a/packages/backend/src/server/api/endpoints/notes/featured.ts
+++ b/packages/backend/src/server/api/endpoints/notes/featured.ts
@@ -98,7 +98,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				]);
 
 				notes = notes.filter(note => {
-					if (isUserRelated(note, userIdsWhoMeMuting, true)) return false;
+					if (isUserRelated(note, userIdsWhoMeMuting)) return false;
 
 					return true;
 				});


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
ミュート対象者本人のノートがignoreAuthorによって除外対象から外されていました。
ユーザー単位ハイライトではそれで良いと考えられますが、全体ハイライトでは残るべきではないはずです。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
fix: #96 

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
isUserRelatedの挙動を勘違いしていたのでレビュー時に見逃してしまいました。
多分これで直ります。多分…

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
