### PR TITLE
fix: note-public-to-home menu used outdated "os.api"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,17 @@
 -
 
 ### Client
-- 
+-
 
 ### Server
 -
 
 -->
+
+## 202x.x.x-kinel.x (unreleased)
+
+### Client
+- Fix: パブリック投稿をホーム投稿に変更するモデレーション操作がUI上で行えなくなっていた問題を修正
 
 ## 2024.3.1-kinel.1
 

--- a/packages/frontend/src/scripts/get-note-menu.ts
+++ b/packages/frontend/src/scripts/get-note-menu.ts
@@ -150,7 +150,7 @@ export function getNoteMenu(props: {
 		}).then(({ canceled }) => {
 			if (canceled) return;
 
-			os.api('admin/note-public-to-home', { noteId: appearNote.id });
+			misskeyApi('admin/note-public-to-home', { noteId: appearNote.id });
 		});
 	}
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
`os.api`のままだったのを`misskeyApi`に直しました。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Fix: #163 

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
多分動くんじゃないですかね(動作未確認)

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
