### PR TITLE
コントロールパネルで「未知のリモートユーザーによる通知を許可するローカルユーザーのID」の欄が非表示ハッシュタグのものになっている問題を修正

### DIFF
--- a/packages/frontend/src/pages/admin/moderation.vue
+++ b/packages/frontend/src/pages/admin/moderation.vue
@@ -60,7 +60,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 						<template #label>未知のリモートユーザーによる通知が発生するノートをブロックする</template>
 					</MkSwitch>
 
-					<MkTextarea v-model="hiddenTags">
+					<MkTextarea v-model="nirilaAllowedUnfamiliarRemoteUserIds">
 						<template #label>未知のリモートユーザーによる通知を許可するローカルユーザーのID</template>
 						<template #caption>`@admin`のようなユーザ名ではなく、`9grmcrkrsl`のようなユーザーのIDであることに注意してください。</template>
 					</MkTextarea>


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
fix: #212 

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
